### PR TITLE
Bugfix import parse() and timeformat in example

### DIFF
--- a/functions/export-to-csv/3.1/function.json
+++ b/functions/export-to-csv/3.1/function.json
@@ -131,7 +131,7 @@
     {
       "name": "dateFormatMapping",
       "label": "Date formatting",
-      "info": "KEY column = column name which is used in the property mapping, VALUE column = Date format (for example: MM-DD-yyyy) see the documentation for more format options",
+      "info": "KEY column = column name which is used in the property mapping, VALUE column = Date format (for example: MM-dd-yyyy) see the documentation for more format options",
       "meta": {
         "type": "Map"
       }

--- a/functions/export-to-csv/3.1/index.js
+++ b/functions/export-to-csv/3.1/index.js
@@ -1,5 +1,5 @@
 import { ExportToCsv } from "export-to-csv";
-import { parseISO, format } from "date-fns";
+import { parseISO, format, parse } from "date-fns";
 import templayed from "../../utils/templayed";
 import XLSX from "../../utils/xlsx.full.min.js";
 


### PR DESCRIPTION
Defines the parse() function import and fixes the wrong timeformat example in the options. Timeformat is now changed to dd-MM-yyyy