### PR TITLE
fix: relational data formatting always empty

### DIFF
--- a/functions/export-to-csv/3.2/index.js
+++ b/functions/export-to-csv/3.2/index.js
@@ -140,7 +140,8 @@ const dataExport = async ({
         result[key] &&
         valueFormat &&
         valueFormat[0] &&
-        valueFormat[1]
+        valueFormat[1] &&
+        typeof result[key] !== "object"
       ) {
         switch (valueFormat[0].toString().toLowerCase()) {
           case "date":


### PR DESCRIPTION
Fix for when formatting was configured for relation data an empty string was always returned.